### PR TITLE
djvulibre: call autoreconf -fi, not change options

### DIFF
--- a/src/djvulibre-1-fixes.patch
+++ b/src/djvulibre-1-fixes.patch
@@ -296,11 +296,11 @@ See http://mingw-users.1079350.n2.nabble.com/MinGW-produces-incorrect-dll-a-file
 but MXE's host is "i686-w64-mingw32.shared". This patch changes the
 pattern to "*-mingw32*".
 
-diff --git a/configure b/configure
-index 1111111..2222222 100755
---- a/configure
-+++ b/configure
-@@ -2927,7 +2927,7 @@ DLLFLAGS=
+diff --git a/configure.ac b/configure.ac
+index 1111111..2222222 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -69,7 +69,7 @@ AC_SUBST(DLLFLAGS)
  
  # Special cases
  case "$host" in

--- a/src/djvulibre.mk
+++ b/src/djvulibre.mk
@@ -18,12 +18,9 @@ define $(PKG)_UPDATE
 endef
 
 define $(PKG)_BUILD
-    cd '$(1)' && CPPFLAGS='-DDLL_EXPORT' ./configure \
+    cd '$(1)' && autoreconf -fi && CPPFLAGS='-DDLL_EXPORT' ./configure \
         $(MXE_CONFIGURE_OPTS) \
-        --disable-desktopfiles \
-        $(if $(BUILD_SHARED),\
-            lt_cv_deplibs_check_method='file_magic file format (pe-i386|pe-x86-64)' \
-            lt_cv_file_magic_cmd='$$OBJDUMP -f')
+        --disable-desktopfiles
     $(MAKE) -C '$(1)' -j '$(JOBS)'
     $(MAKE) -C '$(1)/libdjvu' -j 1 install-lib \
         install-include install-pkgconfig


### PR DESCRIPTION
Changes of ./configure were moved to ./configure.ac
to preserve them after `autoreconf -fi`.

See https://github.com/mxe/mxe/pull/1286#discussion_r59139912